### PR TITLE
Add type alias for our current prototype genome graph.

### DIFF
--- a/bigraph/src/interface/dynamic_bigraph.rs
+++ b/bigraph/src/interface/dynamic_bigraph.rs
@@ -74,7 +74,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{petgraph_impl, BidirectedNodeData, NodeBigraphWrapper, StaticBigraphFromDigraph, StaticBigraph, DynamicBigraph, ImmutableGraphContainer, MutableGraphContainer};
+    use crate::{
+        petgraph_impl, BidirectedNodeData, DynamicBigraph, ImmutableGraphContainer,
+        MutableGraphContainer, NodeBigraphWrapper, StaticBigraph, StaticBigraphFromDigraph,
+    };
 
     #[test]
     fn test_bigraph_add_mirror_edges() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ extern crate error_chain;
 
 use clap::Clap;
 use error_chain::{ChainedError, ExitCode};
-use genome_graph::bigraph::*;
+use genome_graph::types::PetBCalm2Graph;
 
 error_chain! {
     links {
@@ -76,17 +76,8 @@ fn verify(options: &CliOptions) -> Result<()> {
         options.output.as_ref().unwrap_or(&"None".to_owned())
     );
 
-    let genome_graph: NodeBigraphWrapper<
-        genome_graph::io::bcalm2::PlainBCalm2NodeData<usize>,
-        (),
-        usize,
-        genome_graph::bigraph::petgraph::Graph<
-            genome_graph::io::bcalm2::PlainBCalm2NodeData<usize>,
-            (),
-            genome_graph::bigraph::petgraph::Directed,
-            usize,
-        >,
-    > = genome_graph::io::bcalm2::load_bigraph_from_bcalm2(&options.input)?;
+    let genome_graph: PetBCalm2Graph =
+        genome_graph::io::bcalm2::load_bigraph_from_bcalm2(&options.input)?;
     println!("{:?}", genome_graph);
     Ok(())
 }

--- a/genome-graph/src/lib.rs
+++ b/genome-graph/src/lib.rs
@@ -4,6 +4,7 @@ extern crate error_chain;
 
 mod error;
 pub mod io;
+pub mod types;
 
 pub use bigraph;
 pub use error::*;

--- a/genome-graph/src/types.rs
+++ b/genome-graph/src/types.rs
@@ -1,0 +1,11 @@
+pub type PetBCalm2Graph = crate::bigraph::NodeBigraphWrapper<
+    crate::io::bcalm2::PlainBCalm2NodeData<usize>,
+    (),
+    usize,
+    crate::bigraph::petgraph::Graph<
+        crate::io::bcalm2::PlainBCalm2NodeData<usize>,
+        (),
+        crate::bigraph::petgraph::Directed,
+        usize,
+    >,
+>;


### PR DESCRIPTION
Fixes a lint about too large types, and really makes the code more nice.

Resolves #20