### PR TITLE
Extend test cases to multigraphs.

### DIFF
--- a/implementation/bigraph/src/implementation/node_bigraph_wrapper.rs
+++ b/implementation/bigraph/src/implementation/node_bigraph_wrapper.rs
@@ -230,6 +230,10 @@ impl<Topology: ImmutableGraphContainer> ImmutableGraphContainer for NodeBigraphW
         self.topology.contains_edge(from, to)
     }
 
+    fn edge_count_between(&self, from: Self::NodeIndex, to: Self::NodeIndex) -> usize {
+        self.topology.edge_count_between(from, to)
+    }
+
     fn edge_endpoints(&self, edge_id: Self::EdgeIndex) -> Edge<Self::NodeIndex> {
         self.topology.edge_endpoints(edge_id)
     }

--- a/implementation/genome-graph/src/io/bcalm2.rs
+++ b/implementation/genome-graph/src/io/bcalm2.rs
@@ -318,8 +318,8 @@ pub fn read_bigraph_from_bcalm2_as_node_centric<
         bigraph.add_edge(from_node, to_node, EdgeData::default());
     }
 
-    bigraph.add_mirror_edges();
-    assert!(bigraph.verify_mirror_property());
+    bigraph.add_node_centric_mirror_edges();
+    assert!(bigraph.verify_node_mirror_property());
     Ok(bigraph)
 }
 
@@ -540,7 +540,7 @@ where
     }
 
     assert!(bigraph.verify_node_pairing());
-    assert!(bigraph.verify_mirror_property());
+    assert!(bigraph.verify_node_mirror_property());
     Ok(bigraph)
 }
 
@@ -864,6 +864,33 @@ mod tests {
             GGTCTCGGGTAAGT\n\
             >2 LN:i:6 KC:i:15 km:f:2.2 L:+:0:- L:+:1:-\n\
             AAGAAC\n";
+        let input = Vec::from(test_file);
+
+        let graph: PetBCalm2EdgeGraph =
+            read_bigraph_from_bcalm2_as_edge_centric(bio::io::fasta::Reader::new(test_file), 3)
+                .unwrap();
+        let mut output = Vec::new();
+        write_edge_centric_bigraph_to_bcalm2(&graph, bio::io::fasta::Writer::new(&mut output))
+            .unwrap();
+
+        assert_eq!(
+            input,
+            output,
+            "in:\n{}\n\nout:\n{}\n",
+            String::from_utf8(input.clone()).unwrap(),
+            String::from_utf8(output.clone()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_edge_read_write_multigraph() {
+        let test_file: &'static [u8] = b"\
+            >0 LN:i:7 KC:i:4 km:f:3.0 L:+:2:+ L:-:2:-\n\
+            AGTTCTC\n\
+            >1 LN:i:14 KC:i:2 km:f:3.2 L:+:2:+ L:-:2:-\n\
+            AGTCTCGGGTAATC\n\
+            >2 LN:i:6 KC:i:15 km:f:2.2 L:+:0:+ L:+:1:+ L:-:0:- L:-:1:-\n\
+            TCGAAG\n";
         let input = Vec::from(test_file);
 
         let graph: PetBCalm2EdgeGraph =

--- a/implementation/traitgraph/src/algo/components.rs
+++ b/implementation/traitgraph/src/algo/components.rs
@@ -134,9 +134,11 @@ mod tests {
         let n4 = graph.add_node(4);
         let e0 = graph.add_edge(n0, n1, 10);
         let e1 = graph.add_edge(n1, n2, 11);
+        let e15 = graph.add_edge(n1, n2, 115);
         let e2 = graph.add_edge(n2, n3, 12);
         let e3 = graph.add_edge(n3, n4, 13);
         let e4 = graph.add_edge(n4, n0, 14);
+        let e45 = graph.add_edge(n4, n0, 145);
         let e5 = graph.add_edge(n1, n0, 15);
         let e6 = graph.add_edge(n2, n1, 16);
         let e7 = graph.add_edge(n3, n2, 17);
@@ -155,16 +157,18 @@ mod tests {
         assert_eq!(result.node_data(n3), &3);
         assert_eq!(result.node_data(n4), &2);
 
-        assert_eq!(result.edge_data(e0), &14);
-        assert_eq!(result.edge_data(e1), &19);
+        assert_eq!(result.edge_data(e0), &145);
+        assert_eq!(result.edge_data(e1), &14);
+        assert_eq!(result.edge_data(e15), &19);
         assert_eq!(result.edge_data(e2), &15);
         assert_eq!(result.edge_data(e3), &10);
         assert_eq!(result.edge_data(e4), &13);
-        assert_eq!(result.edge_data(e5), &18);
-        assert_eq!(result.edge_data(e6), &20);
-        assert_eq!(result.edge_data(e7), &16);
-        assert_eq!(result.edge_data(e8), &12);
-        assert_eq!(result.edge_data(e9), &17);
+        assert_eq!(result.edge_data(e45), &18);
+        assert_eq!(result.edge_data(e5), &20);
+        assert_eq!(result.edge_data(e6), &16);
+        assert_eq!(result.edge_data(e7), &12);
+        assert_eq!(result.edge_data(e8), &17);
+        assert_eq!(result.edge_data(e9), &115);
         assert_eq!(result.edge_data(e10), &11);
     }
 
@@ -184,6 +188,7 @@ mod tests {
         let e5 = graph.add_edge(n3, n2, 17);
         let e6 = graph.add_edge(n4, n3, 18);
         let e7 = graph.add_edge(n2, n2, 20);
+        let e8 = graph.add_edge(n2, n2, 21);
         let result = decompose_weakly_connected_components(&graph);
         assert_eq!(result.len(), 1);
         let result = result.first().unwrap();
@@ -198,12 +203,13 @@ mod tests {
 
         assert_eq!(result.edge_data(e0), &15);
         assert_eq!(result.edge_data(e1), &10);
-        assert_eq!(result.edge_data(e2), &20);
-        assert_eq!(result.edge_data(e3), &11);
-        assert_eq!(result.edge_data(e4), &17);
-        assert_eq!(result.edge_data(e5), &12);
-        assert_eq!(result.edge_data(e6), &18);
-        assert_eq!(result.edge_data(e7), &13);
+        assert_eq!(result.edge_data(e2), &21);
+        assert_eq!(result.edge_data(e3), &20);
+        assert_eq!(result.edge_data(e4), &11);
+        assert_eq!(result.edge_data(e5), &17);
+        assert_eq!(result.edge_data(e6), &12);
+        assert_eq!(result.edge_data(e7), &18);
+        assert_eq!(result.edge_data(e8), &13);
     }
 
     #[test]
@@ -217,6 +223,7 @@ mod tests {
         let n5 = graph.add_node(5);
         graph.add_edge(n0, n0, 10);
         graph.add_edge(n1, n2, 11);
+        graph.add_edge(n1, n2, 115);
         graph.add_edge(n3, n4, 12);
         graph.add_edge(n4, n5, 13);
         let result = decompose_weakly_connected_components(&graph);
@@ -227,7 +234,7 @@ mod tests {
         assert_eq!(first.node_count(), 1);
         assert_eq!(first.edge_count(), 1);
         assert_eq!(second.node_count(), 2);
-        assert_eq!(second.edge_count(), 1);
+        assert_eq!(second.edge_count(), 2);
         assert_eq!(third.node_count(), 3);
         assert_eq!(third.edge_count(), 2);
 
@@ -239,7 +246,8 @@ mod tests {
         assert_eq!(third.node_data(2.into()), &5);
 
         assert_eq!(first.edge_data(0.into()), &10);
-        assert_eq!(second.edge_data(0.into()), &11);
+        assert_eq!(second.edge_data(0.into()), &115);
+        assert_eq!(second.edge_data(1.into()), &11);
         assert_eq!(third.edge_data(0.into()), &12);
         assert_eq!(third.edge_data(1.into()), &13);
     }
@@ -260,6 +268,7 @@ mod tests {
         let n3 = graph.add_node(3);
         let n4 = graph.add_node(4);
         let e0 = graph.add_edge(n0, n1, 10);
+        let e05 = graph.add_edge(n0, n1, 105);
         let e1 = graph.add_edge(n1, n2, 11);
         let e2 = graph.add_edge(n2, n3, 12);
         let e3 = graph.add_edge(n3, n4, 13);
@@ -283,8 +292,9 @@ mod tests {
         assert_eq!(result.node_data(n4), &2);
 
         assert_eq!(result.edge_data(e0), &19);
-        assert_eq!(result.edge_data(e1), &15);
-        assert_eq!(result.edge_data(e2), &14);
+        assert_eq!(result.edge_data(e05), &15);
+        assert_eq!(result.edge_data(e1), &14);
+        assert_eq!(result.edge_data(e2), &105);
         assert_eq!(result.edge_data(e3), &10);
         assert_eq!(result.edge_data(e4), &13);
         assert_eq!(result.edge_data(e5), &18);
@@ -309,6 +319,7 @@ mod tests {
         let e3 = graph.add_edge(n3, n4, 13);
         let e4 = graph.add_edge(n4, n0, 14);
         let e5 = graph.add_edge(n1, n0, 15);
+        let e55 = graph.add_edge(n1, n0, 155);
         let e6 = graph.add_edge(n2, n1, 16);
         let e7 = graph.add_edge(n3, n2, 17);
         let e8 = graph.add_edge(n4, n3, 18);
@@ -326,12 +337,13 @@ mod tests {
         assert_eq!(result.node_data(n3), &2);
         assert_eq!(result.node_data(n4), &3);
 
-        assert_eq!(result.edge_data(e0), &15);
-        assert_eq!(result.edge_data(e1), &14);
-        assert_eq!(result.edge_data(e2), &10);
-        assert_eq!(result.edge_data(e3), &19);
-        assert_eq!(result.edge_data(e4), &20);
-        assert_eq!(result.edge_data(e5), &16);
+        assert_eq!(result.edge_data(e0), &155);
+        assert_eq!(result.edge_data(e1), &15);
+        assert_eq!(result.edge_data(e2), &14);
+        assert_eq!(result.edge_data(e3), &10);
+        assert_eq!(result.edge_data(e4), &19);
+        assert_eq!(result.edge_data(e5), &20);
+        assert_eq!(result.edge_data(e55), &16);
         assert_eq!(result.edge_data(e6), &11);
         assert_eq!(result.edge_data(e7), &17);
         assert_eq!(result.edge_data(e8), &13);
@@ -353,6 +365,7 @@ mod tests {
         graph.add_edge(n3, n4, 13);
         graph.add_edge(n4, n0, 14);
         graph.add_edge(n1, n0, 15);
+        graph.add_edge(n1, n0, 155);
         graph.add_edge(n2, n1, 16);
         graph.add_edge(n3, n2, 17);
         graph.add_edge(n4, n3, 18);
@@ -374,6 +387,7 @@ mod tests {
         graph.add_edge(n2, n3, 12);
         graph.add_edge(n3, n4, 13);
         graph.add_edge(n1, n0, 15);
+        graph.add_edge(n1, n0, 155);
         graph.add_edge(n3, n2, 17);
         graph.add_edge(n4, n3, 18);
         graph.add_edge(n2, n2, 20);
@@ -393,6 +407,7 @@ mod tests {
         graph.add_edge(n1, n2, 11);
         graph.add_edge(n2, n1, 13);
         graph.add_edge(n3, n4, 12);
+        graph.add_edge(n3, n4, 125);
         graph.add_edge(n4, n5, 13);
         graph.add_edge(n5, n3, 13);
         assert!(!is_strongly_connected(&graph));
@@ -418,6 +433,7 @@ mod tests {
         graph.add_edge(n3, n4, 13);
         graph.add_edge(n4, n1, 14);
         graph.add_edge(n1, n4, 15);
+        graph.add_edge(n1, n4, 155);
         graph.add_edge(n2, n1, 16);
         graph.add_edge(n3, n2, 17);
         graph.add_edge(n4, n3, 18);
@@ -440,6 +456,7 @@ mod tests {
         graph.add_edge(n3, n4, 13);
         graph.add_edge(n4, n0, 14);
         graph.add_edge(n1, n0, 15);
+        graph.add_edge(n1, n0, 155);
         graph.add_edge(n2, n1, 16);
         graph.add_edge(n3, n2, 17);
         graph.add_edge(n4, n3, 18);

--- a/implementation/traitgraph/src/algo/unitigs.rs
+++ b/implementation/traitgraph/src/algo/unitigs.rs
@@ -164,6 +164,7 @@ mod tests {
         graph.add_edge(n4, n8, 15);
         graph.add_edge(n5, n8, 16);
         graph.add_edge(n8, n6, 17);
+        graph.add_edge(n8, n6, 175);
         graph.add_edge(n8, n7, 18);
         graph.add_edge(n6, n0, 19);
         graph.add_edge(n7, n0, 20);
@@ -231,6 +232,7 @@ mod tests {
         graph.add_edge(n4, n8, 15);
         graph.add_edge(n5, n8, 16);
         graph.add_edge(n8, n6, 17);
+        graph.add_edge(n8, n6, 175);
         graph.add_edge(n8, n7, 18);
         graph.add_edge(n6, n0, 19);
         graph.add_edge(n7, n0, 20);
@@ -296,6 +298,7 @@ mod tests {
         graph.add_edge(n4, n8, 15);
         graph.add_edge(n5, n8, 16);
         graph.add_edge(n8, n6, 17);
+        graph.add_edge(n8, n6, 175);
         graph.add_edge(n8, n7, 18);
         graph.add_edge(n6, n0, 19);
         graph.add_edge(n7, n0, 20);
@@ -365,23 +368,24 @@ mod tests {
         graph.add_edge(n4, n8, 15);
         graph.add_edge(n5, n8, 16);
         graph.add_edge(n8, n6, 17);
+        graph.add_edge(n8, n6, 175);
         graph.add_edge(n8, n7, 18);
         graph.add_edge(n6, n0, 19);
         graph.add_edge(n7, n0, 20);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph), 4);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n8, n3, 21);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n0, n8, 22);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n8, n3, 21);
         graph2.add_edge(n0, n8, 22);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
 
         drop(graph); // Against linter errors for last clone.
     }
@@ -404,23 +408,24 @@ mod tests {
         graph.add_edge(n4, n8, 15);
         graph.add_edge(n5, n8, 16);
         graph.add_edge(n8, n6, 17);
+        graph.add_edge(n8, n6, 175);
         graph.add_edge(n8, n7, 18);
         graph.add_edge(n6, n0, 19);
         graph.add_edge(n7, n0, 20);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph), 4);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n8, n3, 21);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n0, n8, 22);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n8, n3, 21);
         graph2.add_edge(n0, n8, 22);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 5);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
 
         drop(graph); // Against linter errors for last clone.
     }
@@ -441,23 +446,24 @@ mod tests {
         graph.add_edge(n4, n8, 15);
         graph.add_edge(n5, n8, 16);
         graph.add_edge(n8, n6, 17);
+        graph.add_edge(n8, n6, 175);
         graph.add_edge(n8, n7, 18);
         graph.add_edge(n6, n0, 19);
         graph.add_edge(n7, n0, 20);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph), 4);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph), 3);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n8, n3, 21);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 3);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n0, n8, 22);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 3);
 
         let mut graph2 = graph.clone();
         graph2.add_edge(n8, n3, 21);
         graph2.add_edge(n0, n8, 22);
-        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 4);
+        assert_eq!(count_uncompacted_edge_unitigs(&graph2), 3);
 
         drop(graph); // Against linter errors for last clone.
     }

--- a/implementation/traitgraph/src/implementation/petgraph_impl.rs
+++ b/implementation/traitgraph/src/implementation/petgraph_impl.rs
@@ -72,6 +72,10 @@ impl<NodeData, EdgeData> ImmutableGraphContainer for DiGraph<NodeData, EdgeData,
             .is_some()
     }
 
+    fn edge_count_between(&self, from: Self::NodeIndex, to: Self::NodeIndex) -> usize {
+        self.edges_connecting(from.into(), to.into()).count()
+    }
+
     fn edge_endpoints(&self, edge_id: Self::EdgeIndex) -> Edge<Self::NodeIndex> {
         let endpoints = self.edge_endpoints(edge_id.into()).unwrap();
         Edge {

--- a/implementation/traitgraph/src/interface/mod.rs
+++ b/implementation/traitgraph/src/interface/mod.rs
@@ -35,6 +35,8 @@ pub trait ImmutableGraphContainer: GraphBase {
 
     fn contains_edge(&self, from: Self::NodeIndex, to: Self::NodeIndex) -> bool;
 
+    fn edge_count_between(&self, from: Self::NodeIndex, to: Self::NodeIndex) -> usize;
+
     fn edge_endpoints(&self, edge_id: Self::EdgeIndex) -> Edge<Self::NodeIndex>;
 
     /// Returns true if the graph is empty, i.e. contains no nodes or edges.


### PR DESCRIPTION
Since we switched to edge-centric de Bruijn graphs, multigraphs may occur. So we need to test for their correctness.

 * Made many graphs in test cases multigraphs, where it is easily possible.
 + Add a separate multigraph I/O test case to the bcalm2 module.
 - Remove verify_unitig_length_is_zero: this was outdated before already.
 * Rename verify_mirror_property to verify_node_mirror_property. The mirror property obeys edge data as well for edge-centric de Bruijn graphs.
 * Rename add_mirror_edges to add_node_centric_mirror_edges, since for edge-centric de Bruijn graphs the edge data needs to be handled differently.

In conclusion, all test cases now use a multigraph, or there is a separate test case with a multigraph for an algorithm.

Closes #66