### PR TITLE
Replace make_bcalm_output_deterministic shell script with python script.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -42,9 +42,9 @@ rule test_single_file:
     shell: "cmp --silent {input.verify} {input.deterministic}"
 
 rule make_bcalm_output_deterministic:
-    input: "data/{file}.unitigs.fa"
+    input: file = "data/{file}.unitigs.fa", script = "scripts/make_bcalm_output_deterministic.py"
     output: "data/{file}.unitigs.fa.deterministic"
-    shell: "scripts/make_bcalm_output_deterministic.sh '{input}' '{output}'"
+    shell: "python scripts/make_bcalm_output_deterministic.py '{input.file}' '{output}'"
 
 rule verify:
     input: file = "data/{file}.unitigs.fa", binary = "data/target/release/cli"

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,3 +4,4 @@ channels:
         - conda-forge
 dependencies: 
         - snakemake==5.20.1
+        - python==3.8.5

--- a/scripts/make_bcalm_output_deterministic.py
+++ b/scripts/make_bcalm_output_deterministic.py
@@ -1,0 +1,39 @@
+#in_file="$1"
+#clean_in_file="$2"
+
+#while read -r line
+#do
+#	if [[ $line == \>* ]]; then
+#		arguments=($line)
+#		result="${arguments[0]} ${arguments[1]} ${arguments[2]} ${arguments[3]}"
+#		arguments=("${arguments[@]:4}")
+#		IFS=$'\n' arguments=($(sort -t ":" -k2,2r -k3,3n <<<"${arguments[*]}"))
+#		unset IFS
+#		arguments=$(printf " %s" "${arguments[@]}")
+#		result=`echo "$result$arguments" | sed 's/ *$//g'`
+#		echo "${result}"
+#	else
+#		echo "$line"
+#	fi
+#done < "$in_file" > "$clean_in_file"
+
+import sys
+
+input = open(sys.argv[1], 'r')
+output = open(sys.argv[2], 'w')
+
+def sort_key(token):
+	bits = token.split(':')
+	bits[1] = 'a' if bits[1] == '+' else 'b'
+	bits[3] = 'a' if bits[3] == '-' else 'b'
+	return (bits[1], int(bits[2]), bits[3])
+
+for line in input:
+	if line.startswith(">"):
+		tokens = list(filter(None, line.split()))
+		const_tokens = tokens[:4]
+		tokens = tokens[4:]
+		tokens = sorted(tokens, key = sort_key)
+		line = ' '.join(const_tokens + tokens) + '\n'
+
+	output.write(line)


### PR DESCRIPTION
This way it does not need to create a process for every second line, but
does everything in one process. So it is much faster.
Moreover, python is much more readable than bash.

Closes #59