### PR TITLE
Let `NavigableGraph` return `Iterator`s instead of `IntoIterator`s.

### DIFF
--- a/implementation/bigraph/src/interface/dynamic_bigraph.rs
+++ b/implementation/bigraph/src/interface/dynamic_bigraph.rs
@@ -37,7 +37,7 @@ where
     fn add_node_centric_mirror_edges(&mut self) {
         let mut edges = Vec::new();
         for from_id in self.node_indices() {
-            let mut out_neighbors: Vec<_> = self.out_neighbors(from_id).into_iter().collect();
+            let mut out_neighbors: Vec<_> = self.out_neighbors(from_id).collect();
             out_neighbors.sort_by(|a, b| a.node_id.cmp(&b.node_id));
             out_neighbors.dedup_by(|a, b| a.node_id == b.node_id);
             for neighbor in out_neighbors {

--- a/implementation/omnitigs/src/unitigs/mod.rs
+++ b/implementation/omnitigs/src/unitigs/mod.rs
@@ -80,7 +80,7 @@ impl<Graph: StaticGraph> Unitigs<Graph> {
                 let mut unitig = vec![end_node, start_node];
 
                 while graph.is_biunivocal_node(start_node) && start_node != end_node {
-                    let in_neighbor = graph.in_neighbors(start_node).into_iter().next().unwrap();
+                    let in_neighbor = graph.in_neighbors(start_node).next().unwrap();
                     start_node = in_neighbor.node_id;
                     used_edges[in_neighbor.edge_id.as_usize()] = true;
                     unitig.push(start_node);
@@ -89,7 +89,7 @@ impl<Graph: StaticGraph> Unitigs<Graph> {
                 unitig.reverse();
 
                 while graph.is_biunivocal_node(end_node) && start_node != end_node {
-                    let out_neighbor = graph.out_neighbors(end_node).into_iter().next().unwrap();
+                    let out_neighbor = graph.out_neighbors(end_node).next().unwrap();
                     end_node = out_neighbor.node_id;
                     used_edges[out_neighbor.edge_id.as_usize()] = true;
                     unitig.push(end_node);

--- a/implementation/omnitigs/src/unitigs/uncompacted_unitigs.rs
+++ b/implementation/omnitigs/src/unitigs/uncompacted_unitigs.rs
@@ -42,14 +42,14 @@ pub fn count_uncompacted_node_unitigs<Graph: StaticGraph>(graph: &Graph) -> Unco
             let mut length = 2usize;
 
             while graph.out_degree(start_index) == 1 && graph.in_degree(start_index) == 1 {
-                let neighbor = graph.in_neighbors(start_index).into_iter().next().unwrap();
+                let neighbor = graph.in_neighbors(start_index).next().unwrap();
 
                 start_index = neighbor.node_id;
                 used_edges[neighbor.edge_id.as_usize()] = true;
                 length += 1;
             }
             while graph.out_degree(end_index) == 1 && graph.in_degree(end_index) == 1 {
-                let neighbor = graph.out_neighbors(end_index).into_iter().next().unwrap();
+                let neighbor = graph.out_neighbors(end_index).next().unwrap();
 
                 end_index = neighbor.node_id;
                 used_edges[neighbor.edge_id.as_usize()] = true;
@@ -93,12 +93,7 @@ pub fn count_uncompacted_edge_unitigs<Graph: StaticGraph>(graph: &Graph) -> usiz
 
         while graph.in_degree(first_node) == 1 && graph.out_degree(first_node) <= 1 {
             used_nodes[first_node.as_usize()] = true;
-            first_node = graph
-                .in_neighbors(first_node)
-                .into_iter()
-                .next()
-                .unwrap()
-                .node_id;
+            first_node = graph.in_neighbors(first_node).next().unwrap().node_id;
 
             if first_node != node {
                 uncompacted = true;
@@ -109,12 +104,7 @@ pub fn count_uncompacted_edge_unitigs<Graph: StaticGraph>(graph: &Graph) -> usiz
 
         while graph.in_degree(last_node) <= 1 && graph.out_degree(last_node) == 1 {
             used_nodes[last_node.as_usize()] = true;
-            last_node = graph
-                .out_neighbors(last_node)
-                .into_iter()
-                .next()
-                .unwrap()
-                .node_id;
+            last_node = graph.out_neighbors(last_node).next().unwrap().node_id;
 
             if last_node != node {
                 uncompacted = true;

--- a/implementation/traitgraph/src/algo/traversal.rs
+++ b/implementation/traitgraph/src/algo/traversal.rs
@@ -281,7 +281,7 @@ impl<'a, Graph: NavigableGraph<'a>> TraversalNeighborStrategy<'a, Graph>
     type Iterator = NeighborsIntoNodes<Graph::NodeIndex, Graph::EdgeIndex, Graph::OutNeighbors>;
 
     fn neighbor_iterator(graph: &'a Graph, node: Graph::NodeIndex) -> Self::Iterator {
-        graph.out_neighbors(node).into_iter().map(|e| e.node_id)
+        graph.out_neighbors(node).map(|e| e.node_id)
     }
 }
 
@@ -293,7 +293,7 @@ impl<'a, Graph: NavigableGraph<'a>> TraversalNeighborStrategy<'a, Graph>
     type Iterator = NeighborsIntoNodes<Graph::NodeIndex, Graph::EdgeIndex, Graph::InNeighbors>;
 
     fn neighbor_iterator(graph: &'a Graph, node: Graph::NodeIndex) -> Self::Iterator {
-        graph.in_neighbors(node).into_iter().map(|e| e.node_id)
+        graph.in_neighbors(node).map(|e| e.node_id)
     }
 }
 
@@ -319,8 +319,7 @@ impl<'a, Graph: NavigableGraph<'a>> TraversalNeighborStrategy<'a, Graph>
     fn neighbor_iterator(graph: &'a Graph, node: Graph::NodeIndex) -> Self::Iterator {
         graph
             .out_neighbors(node)
-            .into_iter()
-            .chain(graph.in_neighbors(node).into_iter())
+            .chain(graph.in_neighbors(node))
             .map(|e| e.node_id)
     }
 }
@@ -379,11 +378,7 @@ mod test {
         let mut ordering =
             DfsPostOrderTraversal::<_, ForwardNeighborStrategy, LinkedList<_>>::new(&graph, n0);
         assert_eq!(
-            graph
-                .out_neighbors(n0)
-                .into_iter()
-                .map(|n| n.node_id)
-                .next(),
+            graph.out_neighbors(n0).map(|n| n.node_id).next(),
             Some(3.into())
         );
         assert_eq!(ordering.next(&graph), Some(n3));

--- a/implementation/traitgraph/src/interface/mod.rs
+++ b/implementation/traitgraph/src/interface/mod.rs
@@ -64,10 +64,10 @@ pub trait MutableGraphContainer: GraphBase {
 }
 
 pub trait NavigableGraph<'a>: GraphBase {
-    type OutNeighbors: IntoIterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
-    type InNeighbors: IntoIterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
-    type OutNeighborsTo: IntoIterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
-    type InNeighborsFrom: IntoIterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
+    type OutNeighbors: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
+    type InNeighbors: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
+    type OutNeighborsTo: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
+    type InNeighborsFrom: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
 
     fn out_neighbors(&'a self, node_id: Self::NodeIndex) -> Self::OutNeighbors;
     fn in_neighbors(&'a self, node_id: Self::NodeIndex) -> Self::InNeighbors;
@@ -84,11 +84,11 @@ pub trait NavigableGraph<'a>: GraphBase {
     ) -> Self::InNeighborsFrom;
 
     fn out_degree(&'a self, node_id: Self::NodeIndex) -> usize {
-        self.out_neighbors(node_id).into_iter().count()
+        self.out_neighbors(node_id).count()
     }
 
     fn in_degree(&'a self, node_id: Self::NodeIndex) -> usize {
-        self.in_neighbors(node_id).into_iter().count()
+        self.in_neighbors(node_id).count()
     }
 
     /// Returns true if the given node has indegree == outdegree == 1.

--- a/implementation/traitgraph/src/walks.rs
+++ b/implementation/traitgraph/src/walks.rs
@@ -63,7 +63,7 @@ impl<Graph: StaticGraph> VecNodeWalk<Graph> {
         for node_pair in self.walk.windows(2) {
             let from = node_pair[0];
             let to = node_pair[1];
-            let mut edges_between = graph.out_neighbors_to(from, to).into_iter();
+            let mut edges_between = graph.out_neighbors_to(from, to);
 
             if let Some(edge) = edges_between.next() {
                 walk.push(edge.edge_id);


### PR DESCRIPTION
The indirection is useless at the moment, as we just returned iterators anyways. In the future, it would be a further indirection to create an `IntoIterator` and `Iterator` separately, if we could just create the `Iterator` and achieve the same effect.

Closes #88