### PR TITLE
Return `EdgeIndex` in `NavigableGraph` if the adjacent node is given.

### DIFF
--- a/implementation/bigraph/src/interface/static_bigraph.rs
+++ b/implementation/bigraph/src/interface/static_bigraph.rs
@@ -78,9 +78,7 @@ pub trait StaticNodeCentricBigraph: StaticBigraph {
         let reverse_to = self.mirror_node(endpoints.from_node)?;
         let mut result = None;
 
-        for reverse_edge in self.out_neighbors_to(reverse_from, reverse_to) {
-            debug_assert_eq!(reverse_edge.node_id, reverse_to);
-            let reverse_edge_id = reverse_edge.edge_id;
+        for reverse_edge_id in self.out_neighbors_to(reverse_from, reverse_to) {
             if let Some(node) = result {
                 if node == edge_id {
                     return Some(reverse_edge_id);
@@ -138,9 +136,7 @@ where
         let edge_data = self.edge_data(edge_id);
         let mut result = None;
 
-        for reverse_edge in self.out_neighbors_to(reverse_from, reverse_to) {
-            debug_assert_eq!(reverse_edge.node_id, reverse_to);
-            let reverse_edge_id = reverse_edge.edge_id;
+        for reverse_edge_id in self.out_neighbors_to(reverse_from, reverse_to) {
             if &edge_data.reverse_complement() == self.edge_data(reverse_edge_id) {
                 if let Some(node) = result {
                     if node == edge_id {

--- a/implementation/traitgraph/src/implementation/petgraph_impl.rs
+++ b/implementation/traitgraph/src/implementation/petgraph_impl.rs
@@ -116,9 +116,9 @@ type PetgraphNeighborTranslator<'a, EdgeData, NodeIndex, EdgeIndex> = Map<
     fn(petgraph::graph::EdgeReference<'a, EdgeData, usize>) -> Neighbor<NodeIndex, EdgeIndex>,
 >;
 
-type PetgraphRestrictedNeighborTranslator<'a, EdgeData, NodeIndex, EdgeIndex> = Map<
+type PetgraphRestrictedNeighborTranslator<'a, EdgeData, EdgeIndex> = Map<
     EdgesConnecting<'a, EdgeData, Directed, usize>,
-    fn(petgraph::graph::EdgeReference<'a, EdgeData, usize>) -> Neighbor<NodeIndex, EdgeIndex>,
+    fn(petgraph::graph::EdgeReference<'a, EdgeData, usize>) -> EdgeIndex,
 >;
 
 impl<'a, NodeData, EdgeData: 'a> NavigableGraph<'a> for DiGraph<NodeData, EdgeData, usize> {
@@ -134,18 +134,10 @@ impl<'a, NodeData, EdgeData: 'a> NavigableGraph<'a> for DiGraph<NodeData, EdgeDa
         <Self as GraphBase>::NodeIndex,
         <Self as GraphBase>::EdgeIndex,
     >;
-    type OutNeighborsTo = PetgraphRestrictedNeighborTranslator<
-        'a,
-        EdgeData,
-        <Self as GraphBase>::NodeIndex,
-        <Self as GraphBase>::EdgeIndex,
-    >;
-    type InNeighborsFrom = PetgraphRestrictedNeighborTranslator<
-        'a,
-        EdgeData,
-        <Self as GraphBase>::NodeIndex,
-        <Self as GraphBase>::EdgeIndex,
-    >;
+    type OutNeighborsTo =
+        PetgraphRestrictedNeighborTranslator<'a, EdgeData, <Self as GraphBase>::EdgeIndex>;
+    type InNeighborsFrom =
+        PetgraphRestrictedNeighborTranslator<'a, EdgeData, <Self as GraphBase>::EdgeIndex>;
 
     fn out_neighbors(&'a self, node_id: <Self as GraphBase>::NodeIndex) -> Self::OutNeighbors {
         debug_assert!(self.contains_node_index(node_id));
@@ -173,10 +165,7 @@ impl<'a, NodeData, EdgeData: 'a> NavigableGraph<'a> for DiGraph<NodeData, EdgeDa
         debug_assert!(self.contains_node_index(from_node_id));
         debug_assert!(self.contains_node_index(to_node_id));
         self.edges_connecting(from_node_id.into(), to_node_id.into())
-            .map(|edge| Neighbor {
-                edge_id: <Self as GraphBase>::EdgeIndex::from(edge.id().index()),
-                node_id: <Self as GraphBase>::NodeIndex::from(edge.target().index()),
-            })
+            .map(|edge| <Self as GraphBase>::EdgeIndex::from(edge.id().index()))
     }
 
     fn in_neighbors_from(
@@ -187,10 +176,7 @@ impl<'a, NodeData, EdgeData: 'a> NavigableGraph<'a> for DiGraph<NodeData, EdgeDa
         debug_assert!(self.contains_node_index(from_node_id));
         debug_assert!(self.contains_node_index(to_node_id));
         self.edges_connecting(from_node_id.into(), to_node_id.into())
-            .map(|edge| Neighbor {
-                edge_id: <Self as GraphBase>::EdgeIndex::from(edge.id().index()),
-                node_id: <Self as GraphBase>::NodeIndex::from(edge.source().index()),
-            })
+            .map(|edge| <Self as GraphBase>::EdgeIndex::from(edge.id().index()))
     }
 }
 

--- a/implementation/traitgraph/src/interface/mod.rs
+++ b/implementation/traitgraph/src/interface/mod.rs
@@ -66,8 +66,8 @@ pub trait MutableGraphContainer: GraphBase {
 pub trait NavigableGraph<'a>: GraphBase {
     type OutNeighbors: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
     type InNeighbors: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
-    type OutNeighborsTo: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
-    type InNeighborsFrom: Iterator<Item = Neighbor<Self::NodeIndex, Self::EdgeIndex>>;
+    type OutNeighborsTo: Iterator<Item = Self::EdgeIndex>;
+    type InNeighborsFrom: Iterator<Item = Self::EdgeIndex>;
 
     fn out_neighbors(&'a self, node_id: Self::NodeIndex) -> Self::OutNeighbors;
     fn in_neighbors(&'a self, node_id: Self::NodeIndex) -> Self::InNeighbors;

--- a/implementation/traitgraph/src/walks.rs
+++ b/implementation/traitgraph/src/walks.rs
@@ -66,7 +66,7 @@ impl<Graph: StaticGraph> VecNodeWalk<Graph> {
             let mut edges_between = graph.out_neighbors_to(from, to);
 
             if let Some(edge) = edges_between.next() {
-                walk.push(edge.edge_id);
+                walk.push(edge);
             } else {
                 panic!("Not a valid node walk");
             }


### PR DESCRIPTION
Let `NavigableGraph::out_neighbors_to` and `NavigableGraph::in_neighbors_from` return `EdgeIndex` instead of `Neighbor`, as they take the adjacent node as argument, so it does not need to be repeated in the return values.

Closes #89